### PR TITLE
compat: Normalize upcoming TypeEgal function wrappers

### DIFF
--- a/src/fchain.jl
+++ b/src/fchain.jl
@@ -30,11 +30,18 @@ with_intermediate_results(f, x) = (f(x),)
 
 _typed_funcs_tuple(fs::Vararg{Function,N}) where N = (fs...,)
 
+function _type_callable_arg(T::Type)
+    if isdefined(Core, :TypeEgal) && Base.isType(T)
+        return Type{Base.type_parameter(T)}
+    end
+    return T
+end
+
 @inline @generated function _typed_funcs_tuple(fs::Vararg{Any,N}) where N
     expr = Expr(:tuple)
     for i in 1:N
         if fs[i] <: Type
-            push!(expr.args, :(AsFunction{$(fs[i])}(fs[$i])))
+            push!(expr.args, :(AsFunction{$(_type_callable_arg(fs[i]))}(fs[$i])))
         # Future option (breaking) - flatten FunctionChains:
         # elseif fs[i] <: FunctionChain{<:Tuple}
         #    push!(expr.args, :(fs[$i]._fs...))
@@ -438,7 +445,11 @@ export ffchain
     expr = Expr(:tuple)
     for i in 1:N
         if !(fs[i] <: typeof(identity))
-            push!(expr.args, :(_flat_fs(fs[$i])...))
+            if fs[i] <: Type
+                push!(expr.args, :((AsFunction{$(_type_callable_arg(fs[i]))}(fs[$i]),)...))
+            else
+                push!(expr.args, :(_flat_fs(fs[$i])...))
+            end
         end
     end
     if length(expr.args) == 0

--- a/test/test_fchain.jl
+++ b/test/test_fchain.jl
@@ -113,6 +113,7 @@ include("testfuncs.jl")
         @test @inferred(fchain((log, exp))) isa FunctionChain
         @test @inferred(fchain(a = log, c = exp)) isa FunctionChain
         @test @inferred(fchain((a = log, c = exp))) isa FunctionChain
+        @test fchainfs(@inferred(fchain(Int, Float32))) isa Tuple{FunctionChains.AsFunction{Type{Int}}, FunctionChains.AsFunction{Type{Float32}}}
         @test @inferred(fchain([log, exp])) isa FunctionChain
         @test @inferred(fchain(log, ForwardDiff.Dual)) isa FunctionChain
         @test @inferred(fchain(log, AbstractFloat)) isa FunctionChain


### PR DESCRIPTION
The Base PR JuliaLang/julia#62001 is expected to spell exact closed type-object dispatch keys as Core.TypeEgal. Canonicalize TypeEgal and TypeEq singleton type wrappers before generated function-chain constructors store them in AsFunction parameters, so type-valued callable wrappers remain stable across the upcoming Julia change.

AI disclosure: This commit was prepared with assistance from generative AI. The resulting PR should be checked carefully by a maintainer before merging.